### PR TITLE
Eliminates additional functions and forced down casting by constraining associated types

### DIFF
--- a/GenericCellControllers/Source/CellControllers/GenericCellController.swift
+++ b/GenericCellControllers/Source/CellControllers/GenericCellController.swift
@@ -17,35 +17,19 @@ open class GenericCellController<T: ReusableCell> : CellController<T.CellHolder>
         return T.self
     }
 
-    public final override func configureCell(_ cell: T.CellHolder.CellType) {
-        let cell = cell as! T
-        configureCell(cell)
+    open override func configureCell(_ cell: T) {
+		// By default do nothing.
     }
 
     public final func currentCell() -> T? {
-        return innerCurrentCell() as? T
+		return innerCurrentCell()
     }
 
-    public final override func willDisplayCell(_ cell: T.CellHolder.CellType) {
-        let cell = cell as! T
-        willDisplayCell(cell)
+    open override func willDisplayCell(_ cell: T) {
+		// By default do nothing.
     }
 
-    public final override func didEndDisplayingCell(_ cell: T.CellHolder.CellType) {
-        let cell = cell as! T
-        didEndDisplayingCell(cell)
+    open override func didEndDisplayingCell(_ cell: T) {
+		// By default do nothing.
     }
-
-    open func configureCell(_ cell: T) {
-        // By default do nothing.
-    }
-
-    open func willDisplayCell(_ cell: T) {
-        // By default do nothing.
-    }
-
-    open func didEndDisplayingCell(_ cell: T) {
-        // By default do nothing.
-    }
-
 }

--- a/GenericCellControllers/Source/ReusableCell/ReusableCellHolder.swift
+++ b/GenericCellControllers/Source/ReusableCell/ReusableCellHolder.swift
@@ -10,7 +10,7 @@ import Foundation
 
 // MARK: - ReusableCell
 public protocol ReusableCell: class {
-    associatedtype CellHolder: ReusableCellHolder
+	associatedtype CellHolder: ReusableCellHolder where CellHolder.CellType == Self
 }
 
 extension UITableViewCell: ReusableCell {


### PR DESCRIPTION
It helped me a lot to get rid of repetitive code and apply the factory pattern. However, I found that a more concise source code can be provided through a small modification of the associated type.

So I want to suggest one tiny opinion for this repository as a junior iOS developer. 😃 